### PR TITLE
Corrected overriding the method redcap_module_link_check_display()

### DIFF
--- a/ViderExternalModule.php
+++ b/ViderExternalModule.php
@@ -6,8 +6,8 @@ use ExternalModules\ExternalModules;
 
 class ViderExternalModule extends AbstractExternalModule
 {
-	public function redcap_module_link_check_display()
+	public function redcap_module_link_check_display($project_id, $link)
 	{
-		return true;
+		return $link;
 	}
 }


### PR DESCRIPTION
Bug fix: The overridden method is corrected so that `redcap_module_link_check_display($project_id, $link)` returns `$link` to make the plugin page accessible for all project users.

See `[your REDCap server]/Plugins/index.php?page=ext_mods_docs/methods.md#em-hooks` as an admin for more information